### PR TITLE
Add badges, swap website from ftp to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Overview
 
+![Last Run](https://github.com/fartbagxp/rir-backup/actions/workflows/main.yml/badge.svg)
+![main](https://img.shields.io/github/last-commit/fartbagxp/rir-backup/main)
+
 This repository is intended to backup the Regional Internet Registries Statistics website for IP registration information, including what Autonomous System Number (ASN) an IP may belong to.
 
 It is intended to run nightly.
 
 ## Information Location
 
-The information came from http://www-public.it-sudparis.eu/~maigron/RIR_Stats/index.html.
+The information came from [EU's RIR public stats](http://www-public.it-sudparis.eu/~maigron/RIR_Stats/index.html).
 
 ## What is possible with this data?
 
-It is possible to use this data to identify where IP addresses are: https://github.com/ipverse/rir-ip
+It is possible to use this data to identify [reverse lookup the location of the IP address](https://github.com/ipverse/rir-ip).

--- a/backup.sh
+++ b/backup.sh
@@ -6,22 +6,22 @@ set -eu
 target="${1}/data/raw"
 
 echo delegated-afrinic-extended-latest
-curl --retry 5 --max-time 180 -f -o "${target}/delegated-afrinic-extended-latest.txt" ftp://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-extended-latest
+curl --retry 5 --max-time 180 -f -o "${target}/delegated-afrinic-extended-latest.txt" https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-extended-latest
 
 echo delegated-apnic-extended-latest
-curl --retry 5 --max-time 180 -f -o "${target}/delegated-apnic-extended-latest.txt" ftp://ftp.apnic.net/pub/stats/apnic/delegated-apnic-extended-latest
+curl --retry 5 --max-time 180 -f -o "${target}/delegated-apnic-extended-latest.txt" https://ftp.apnic.net/pub/stats/apnic/delegated-apnic-extended-latest
 
 echo delegated-arin-extended-latest
-curl --retry 5 --max-time 180 -f -o "${target}/delegated-arin-extended-latest.txt" ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest
+curl --retry 5 --max-time 180 -f -o "${target}/delegated-arin-extended-latest.txt" https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest
 
 echo delegated-lacnic-extended-latest
-curl --retry 5 --max-time 180 -f -o "${target}/delegated-lacnic-extended-latest.txt" ftp://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest
+curl --retry 5 --max-time 180 -f -o "${target}/delegated-lacnic-extended-latest.txt" https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest
 
 echo delegated-ripencc-extended-latest
-curl --retry 5 --max-time 180 -o "${target}/delegated-ripencc-extended-latest.txt" ftp://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-extended-latest
+curl --retry 5 --max-time 180 -o "${target}/delegated-ripencc-extended-latest.txt" https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-extended-latest
 
 echo ripe-ncc-allocated-list
-curl --retry 5 --max-time 180 -o "${target}/ripe-ncc-alloclist.txt" ftp://ftp.ripe.net/pub/stats/ripencc/membership/alloclist.txt
+curl --retry 5 --max-time 180 -o "${target}/ripe-ncc-alloclist.txt" https://ftp.ripe.net/pub/stats/ripencc/membership/alloclist.txt
 
 echo asn-listing
 curl --retry 5 --max-time 180 -o "${target}/autnums.html" https://bgp.potaroo.net/cidr/autnums.html


### PR DESCRIPTION
- Adding badges for the last cron job run and last commit.
- Swap links from ftp -> https. That appears to be more stable now that these RIR links support it.